### PR TITLE
Update wrong regexp Processing a text file

### DIFF
--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -192,7 +192,7 @@ async function* makeTextFileLineIterator(fileURL) {
   let { value: chunk, done: readerDone } = await reader.read();
   chunk = chunk ? utf8Decoder.decode(chunk) : "";
 
-  const re = /\n|\r|\r\n/gm;
+  const re = /\r\n|\n|\r/gm;
   let startIndex = 0;
   let result;
 


### PR DESCRIPTION
Update wrong regexp to processing a text file line by line in using_fetch api doc

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Update wrong regexp for processing text line by line in fetch api.

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

const re = /\n|\r|\r\n/gm; would match \n or \r first before the actual \r\n returning unnecessary empty string for each such sequence
updating it to const re = /\r\n|\n|\r/gm; solves the issue.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->

"Fixes #24749" 

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
